### PR TITLE
Fix UTF-8 python encode error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x
 RUN pip3 install selenium
 RUN pip3 install pyvirtualdisplay
 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 ENV APP_HOME /usr/src/app
 WORKDIR /$APP_HOME


### PR DESCRIPTION
When dealing with UTF-8 i've got the error: 
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)

It can be fixed with changing locale from POSIX to C.UTF-8