### PR TITLE
Updated to fix problem with google-chrome-stable depends on libgbm1 (…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN FIREFOX_SETUP=firefox-setup.tar.bz2 && \
 
 
 # install chromedriver and google-chrome
-
+RUN apt install libgbm1  -y
 RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
     wget https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip -d /usr/bin && \


### PR DESCRIPTION
…>= 8.1~0)


I was getting a:
`dpkg: dependency problems prevent configuration of google-chrome-stable:
 google-chrome-stable depends on libgbm1 (>= 8.1~0); however:
  Package libgbm1 is not installed.

dpkg: error processing package google-chrome-stable (--install):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 google-chrome-stable
`
I added it, thanks.