### PR TITLE
Fix Unable / Not install google-chrome-stable in Mac M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:latest
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN echo "===> Installing system dependencies..." && \


### PR DESCRIPTION
Solven the error:

```shell
dpkg: error processing package google-chrome-stable (--install):
...
```

The problem is the architecture in the docker file; the solution set in the main image the arch (amd64 for the last stable version by ubuntu)

Issus related:

-[https://github.com/dimmg/dockselpy/pull/6]( https://github.com/dimmg/dockselpy/pull/6)
-[https://github.com/dimmg/dockselpy/issues/7](https://github.com/dimmg/dockselpy/issues/7)